### PR TITLE
Add Azure OpenAI assistant features cost tracking

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -101,6 +101,20 @@ MAX_TILE_HEIGHT = int(os.getenv("MAX_TILE_HEIGHT", 512))
 OPENAI_FILE_SEARCH_COST_PER_1K_CALLS = float(
     os.getenv("OPENAI_FILE_SEARCH_COST_PER_1K_CALLS", 2.5 / 1000)
 )
+# Azure OpenAI Assistants feature costs
+# Source: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/
+AZURE_FILE_SEARCH_COST_PER_GB_PER_DAY = float(
+    os.getenv("AZURE_FILE_SEARCH_COST_PER_GB_PER_DAY", 0.1)  # $0.1 USD per 1 GB/Day
+)
+AZURE_CODE_INTERPRETER_COST_PER_SESSION = float(
+    os.getenv("AZURE_CODE_INTERPRETER_COST_PER_SESSION", 0.03)  # $0.03 USD per 1 Session
+)
+AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS = float(
+    os.getenv("AZURE_COMPUTER_USE_INPUT_COST_PER_1K_TOKENS", 3.0)  # $0.003 USD per 1K Tokens
+)
+AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS = float(
+    os.getenv("AZURE_COMPUTER_USE_OUTPUT_COST_PER_1K_TOKENS", 12.0)  # $0.012 USD per 1K Tokens
+)
 MIN_NON_ZERO_TEMPERATURE = float(os.getenv("MIN_NON_ZERO_TEMPERATURE", 0.0001))
 #### RELIABILITY ####
 REPEATED_STREAMING_CHUNK_LIMIT = int(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -23,6 +23,12 @@
             "search_context_size_medium": 0.0,
             "search_context_size_high": 0.0
         },
+        "file_search_cost_per_1k_calls": 0.0,
+        "file_search_cost_per_gb_per_day": 0.0,
+        "vector_store_cost_per_gb_per_day": 0.0,
+        "computer_use_input_cost_per_1k_tokens": 0.0,
+        "computer_use_output_cost_per_1k_tokens": 0.0,
+        "code_interpreter_cost_per_session": 0.0,
         "supported_regions": [
             "global",
             "us-west-2",


### PR DESCRIPTION
## Title

Add Azure OpenAI assistant features cost tracking

## Relevant issues

Addresses Azure's new pricing for assistant features including file search, code interpreter, and computer use.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally 
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

### Overview
Implements comprehensive cost tracking for Azure OpenAI's new assistant features based on their official pricing structure.

### Features Added
- **File Search**: $0.1 USD per 1 GB/Day (storage-based pricing)
- **Code Interpreter**: $0.03 USD per session
- **Computer Use**: $0.003 input + $0.012 output per 1K tokens

### Implementation Details
- **Provider-aware pricing**: Different cost calculation logic for Azure vs OpenAI
- **Model-specific overrides**: JSON config allows per-model pricing customization
- **Environment configurable**: All pricing can be overridden via environment variables
- **Backwards compatible**: Existing OpenAI pricing functionality unchanged

### Files Modified
- `litellm/constants.py`: Added Azure-specific pricing constants
- `litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py`: Enhanced cost tracking logic
- `model_prices_and_context_window.json`: Extended pricing schema with new fields

### Technical Implementation
- Dual pricing models: OpenAI (call-based) vs Azure (usage-based)
- Accumulative cost calculation for multiple Azure assistant features
- Safe fallbacks with default pricing when specific values unavailable